### PR TITLE
add methods to exclude a single share server from ensure runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ The manila-manage-extension cli offers:
 
 - `manila-manage-extension share follow_server_migrate SHARE_SERVER_UUID --currenthost CURRENT_HOST --newhost NEW_HOST` subcommand to adjust manila owned objects (share server, share instance, share, manila neutron port) after a volume migration was performed on the back-end storage box
 - `manila-manage-extension share undelete SHARE_UUID` subcommand to restore a soft-deleted share and related objects
+- `manila-manage-extension share server_set_skip_ensure SHARE_SERVER_UUID SKIP_REASON` subcommand to set a flag at share server backend details to skip share server ensure runs, a reason should be provided
+- `manila-manage-extension share server_unset_skip_ensure SHARE_SERVER_UUID` subcommand to undo skipping of share server ensure runs, removes respective keys at share server backend details
 
 ## Installation
 


### PR DESCRIPTION
Sometimes we want to be able to change certain settings on the storage backend and don't want our ensure loop to set those back to our common configuration. In such cases we mark the share server in the backend details with a certain flag 'skip_ensure' and can also provide a reason for doing so with the key 'skip_ensure_comment'.

e.g.
```
manila-manage-extension share server_set_skip_ensure_flag 7fd26b08-3b4e-42b6-bf75-1c312b80c8ab 'special vserver nfs config for valued client Z'
added share server backend details:
{'skip_ensure': 'yes',
 'skip_ensure_comment': 'special vserver nfs config for valued client Z'}
```

and to remove the flag again
```
manila-manage-extension share server_unset_skip_ensure_flag 7fd26b08-3b4e-42b6-bf75-1c312b80c8ab
remaining share server backend details:
{'nfs_config': '{"tcp-max-xfer-size": "262144", "udp-max-xfer-size": "32768"}',
 'ports': '{"7c601db2-0c30-4a38-ae4e-02d432925659": "10.180.0.9", '
          '"e4dd1249-ab12-46ef-91ad-209822eb24a7": "10.180.0.53"}',
 'vserver_name': 'ma_7fd26b08-3b4e-42b6-bf75-1c312b80c8ab'}
```